### PR TITLE
Reduce the size of the high carbon alt text

### DIFF
--- a/style.css
+++ b/style.css
@@ -798,7 +798,7 @@ div.carbon-alt {
 	left: 10%;
 	top: 50%;
 	transform: translateY(-50%);
-	font-size: 3em;
+	font-size: 2em;
 	font-style: italic;
 	line-height: 1.3;
 	z-index: -1;


### PR DESCRIPTION
This little fix should resolve #13 , helpfully reported by Laurence.

https://github.com/climateaction-tech/branch-theme/issues/13