### PR TITLE
Fix image appearance during high carbon intensity

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -192,7 +192,7 @@ function branch_grid_intensity() {
 		function changeGridIntensity( intensity ) {
 			let logo
 			let entryContent = document.querySelector('.entry-content')
-			let figures = document.querySelectorAll('.entry-content .wp-block-image figure, .entry-content figure.wp-block-image');
+			let figures = document.querySelectorAll('.entry-content .wp-block-image figure, .entry-content figure.wp-block-image, .entry-content figure.wp-block-gallery figure');
 
 			document.querySelector('body').classList.add(`${intensity}-grid-intensity`);
 			document.querySelector('.intensity').textContent = intensity;

--- a/functions.php
+++ b/functions.php
@@ -189,37 +189,71 @@ function branch_grid_intensity() {
 			return item.value
 		}
 
+		/**
+		 * Responds to grid intensity changes.
+		 *
+		 * @todo Refactor this horrible code!
+		 *
+		 * @param {string} intensity - Current grid intensity: 'high', 'moderate' or 'low'.
+		 * @return {undefined} - Returns nothing.
+		 */
 		function changeGridIntensity( intensity ) {
-			let logo
-			let entryContent = document.querySelector('.entry-content')
-			let figures = document.querySelectorAll('.entry-content .wp-block-image figure, .entry-content figure.wp-block-image, .entry-content figure.wp-block-gallery figure');
+			const entryContent = document.querySelector('.entry-content'), figures = document.querySelectorAll('.entry-content .wp-block-image figure:not(.no-carbon), .entry-content figure.wp-block-image:not(.no-carbon), .entry-content figure.wp-block-gallery figure:not(.no-carbon)');
+			let logo;
 
 			document.querySelector('body').classList.add(`${intensity}-grid-intensity`);
 			document.querySelector('.intensity').textContent = intensity;
 
 			if ( 'high' == intensity ) {
 				logo = 'orange'
+
 				document.documentElement.style.setProperty('--bg-colour', '#FFBF43');
 				document.documentElement.style.setProperty('--hl-colour', '#472E00');
 				document.documentElement.style.setProperty('--body-colour', '#1E1E1E');
+
 				figures.forEach( function(figure) {
-					let image = figure.querySelector('img');
+
+					const image = figure.querySelector('img');
+
 					if ( image ) {
-						let figureWidth, figureHeight
-						if ( image.width < entryContent.offsetWidth ) {
-							figureWidth = image.width
-							figureHeight = image.height
+
+						const isInGallery = figure.closest('.wp-block-gallery'), imgSpan = document.createElement("span");
+
+						if ( null !== isInGallery ) {
+
+							const imgPlaceholder = document.createElement("img");
+
+							imgPlaceholder.className = 'branch-placeholder-image';
+							imgPlaceholder.src = '/wp-content/themes/branch-theme/images/solid-placeholder.php?bg=ffdd9c&w=' + image.width + '&h=' + image.height;
+							imgPlaceholder.width = image.width;
+							imgPlaceholder.height = image.height;
+
+							figure.appendChild(imgPlaceholder);
+							figure.style.position = 'relative';
+
+							imgSpan.style.position = 'absolute';
+							imgSpan.style.width = '100%';
+							imgSpan.style.height = '100%';
+
 						} else {
-							figureWidth = entryContent.offsetWidth
-							figureHeight = (entryContent.offsetWidth / image.width) * image.height
+
+							let figureWidth, figureHeight
+
+							if ( image.width < entryContent.offsetWidth ) {
+								figureWidth = image.width
+								figureHeight = image.height
+							} else {
+								figureWidth = entryContent.offsetWidth
+								figureHeight = (entryContent.offsetWidth / image.width) * image.height
+							}
+
+							imgSpan.style.width = figureWidth + 'px';
+							imgSpan.style.height = figureHeight + 'px';
 						}
-						//figure.style.width = figureWidth + 'px'
-						//figure.style.height = figureHeight + 'px'
-						const imgSpan = document.createElement("span");
+
 						imgSpan.className = image.classList;
-						imgSpan.style.width = figureWidth + 'px';
-						imgSpan.style.height = figureHeight + 'px';
 						imgSpan.style.display = 'inline-block';
+
 						if ( figure.querySelector('a img') ) {
 							imageLink = figure.querySelector('a');
 							figure.insertBefore(imgSpan, imageLink);
@@ -229,16 +263,21 @@ function branch_grid_intensity() {
 						} else {
 							figure.insertBefore(imgSpan, image);
 						}
+
 						figure.addEventListener( "click", showImage )
+
 						function showImage() {
 							image.style.setProperty( "display", "initial", "important" );
 							this.querySelector('span').remove();
+							this.querySelector('.branch-placeholder-image').remove();
 						}
+
 						const altDiv = document.createElement("div")
 						const altContent = document.createTextNode(image.alt)
 						altDiv.appendChild(altContent);
 						altDiv.className = "carbon-alt";
 						imgSpan.appendChild(altDiv);
+
 						const showDiv = document.createElement("div");
 						const showContent = document.createTextNode("Show Image");
 						showDiv.appendChild(showContent);

--- a/functions.php
+++ b/functions.php
@@ -231,7 +231,7 @@ function branch_grid_intensity() {
 						}
 						figure.addEventListener( "click", showImage )
 						function showImage() {
-							image.style.display = 'initial';
+							image.style.setProperty( "display", "initial", "important" );
 							this.querySelector('span').remove();
 						}
 						const altDiv = document.createElement("div")
@@ -257,7 +257,7 @@ function branch_grid_intensity() {
 					if ( image ) {
 						image.src = image.src.replace(re, "$1/$2/low-res/");
 						image.srcset = image.srcset.replaceAll(re, "$1/$2/low-res/");
-						image.style.display = 'initial';
+						image.style.setProperty( "display", "initial", "important" );
 					}
 					let pictureSource = figure.querySelector('picture source');
 					if ( pictureSource ) {
@@ -272,7 +272,7 @@ function branch_grid_intensity() {
 				figures.forEach( function(figure) {
 					let image = figure.querySelector('img');
 					if ( image ) {
-						image.style.display = 'initial';
+						image.style.setProperty( "display", "initial", "important" );
 					}
 				})
 			}

--- a/images/solid-placeholder.php
+++ b/images/solid-placeholder.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * Produces blank placeholder images on demand.
+ *
+ * Accepts background, width and height values and outputs a plain PNG image of
+ * the specified background color.
+ */
+$settings = [
+	"background" => isset($_GET['bg']) ? $_GET['bg'] : 'ffdd9c',
+	"width" => isset($_GET['w']) ? $_GET['w'] : 400,
+	"height" => isset($_GET['h']) ? $_GET['h'] : 300,
+];
+
+$background = explode(",",hex2rgb($settings['background']));
+$width = $settings['width'];
+$height = $settings['height'];
+
+$image = @imagecreate($width, $height) or die("Cannot Initialize new GD image stream");
+
+$background_color = imagecolorallocate($image, $background[0], $background[1], $background[2]);
+
+imagettftext($image, $font_size, 0, $x, $y, $text_color, $font, $text);
+
+header('Content-Type: image/png');
+
+imagepng($image);
+
+imagedestroy($image);
+
+
+// Convert color code to rgb
+function hex2rgb($hex) {
+    $hex = str_replace("#", "", $hex);
+
+    switch(strlen($hex)){
+        case 1:
+            $hex = $hex.$hex;
+        case 2:
+            $r = hexdec($hex);
+            $g = hexdec($hex);
+            $b = hexdec($hex);
+            break;
+        case 3:
+            $r = hexdec(substr($hex,0,1).substr($hex,0,1));
+            $g = hexdec(substr($hex,1,1).substr($hex,1,1));
+            $b = hexdec(substr($hex,2,1).substr($hex,2,1));
+            break;
+        default:
+            $r = hexdec(substr($hex,0,2));
+            $g = hexdec(substr($hex,2,2));
+            $b = hexdec(substr($hex,4,2));
+            break;
+    }
+
+    $rgb = array($r, $g, $b);
+    return implode(",", $rgb); 
+}

--- a/style.css
+++ b/style.css
@@ -900,7 +900,7 @@ body {
 	text-transform: uppercase;
 }
 
-.entry-content .wp-block-image figure span, .entry-content figure.wp-block-image span {
+.entry-content .wp-block-image figure span, .entry-content figure.wp-block-image span, .entry-content li.blocks-gallery-item span {
 	position: relative;
 	background-color: #FFDD9C;
 	z-index: 0;
@@ -936,6 +936,7 @@ div.show-image {
 	transform: translateX(-50%);
 	bottom: 15%;
 	font-family: "Rubik Bold";
+	text-align: center;
 	text-transform: uppercase;
 	text-decoration: underline;
 	cursor: pointer;

--- a/style.css
+++ b/style.css
@@ -942,8 +942,9 @@ div.show-image {
 	z-index: -1;
 }
 
+/* Hide all images by default. How they appear depends on carbon intensity. */
 .entry-content img {
-	display: none;
+	display: none !important;
 }
 
 .entry-content a.more-link {

--- a/style.css
+++ b/style.css
@@ -942,8 +942,9 @@ div.show-image {
 	z-index: -1;
 }
 
-/* Hide all images by default. How they appear depends on carbon intensity. */
-.entry-content img {
+/* Hide all images by default. How they appear depends on carbon intensity.
+ * (Except for specifically whitelisted images and placeholders.) */
+.entry-content figure:not(.no-carbon) img:not(.branch-placeholder-image) {
 	display: none !important;
 }
 


### PR DESCRIPTION
There have been several reports of images not displaying correctly when the website is in high carbon intensity mode. Almost every issue I've seen here is caused by new developments with the WordPress block editor interfering with the original code for handling carbon intensity settings. Namely, through the (entirely reasonable) use of the `display` CSS property.

Switching to using `!important` priority – as per this PR – appears to fix almost all (if not all) of these issues.

This is merged to `staging` and can be tested here: https://branch-staging.climateaction.tech/

As far as I've tested it, it causes no interference with existing content.

**Update:** I've added a further commit which widens the net to ensure images in the new block editor's gallery elements aren't ignored.

**Further update – 9 June 2023:** After testing with lots of the problematic issue 4 content, I realised a number of problems were persisting. One particular issue of the new gallery block is that it relies heavily on `flexbox`, which means the dimensions of images it contains cannot be relied upon. This PR therefore now contains an image placeholder generator that can generate replica images of the same dimensions as images waiting to load.

These allow us to effectively simulate how the gallery will be laid out, and give us a pixel-perfect preview before we choose whether to view an image. These placeholder images only cost about a KB of transferred data. This is now live on staging, where [this particularly troubling post](https://branch-staging.climateaction.tech/issues/issue-4/norco/) can now be seen in its fixed state.

Before:

![Screenshot 2023-06-09 at 17-53-13 NORCO](https://github.com/climateaction-tech/branch-theme/assets/751476/0f4812c8-1b2a-48c3-af5d-ccd7c8b45175)

After:

![Screenshot 2023-06-09 at 17-53-32 NORCO](https://github.com/climateaction-tech/branch-theme/assets/751476/500599dd-c211-423d-adce-9f86ad00a00e)