### PR TITLE
Fix tappable tooltip on mobile

### DIFF
--- a/style.css
+++ b/style.css
@@ -1504,7 +1504,7 @@ select.select-list__linked {
 	font-family: 'Rubik Bold';
 	text-align: right;
 	display: flex;
-	align-items: center;
+	align-items: end;
 	justify-content: flex-end;
 	flex-direction: column;
 	line-height: 1.2;
@@ -1532,6 +1532,12 @@ select.select-list__linked {
 	.carbon-switcher span.hide-on-mobile {
 		display: none;
 	}
+}
+
+/* Alter selectr's default width of 100% as it isn't necessary and causes a
+ * conflict with the Tippy tooltip. */
+.carbon-switcher .selectr-container {
+	width: auto;
 }
 
 


### PR DESCRIPTION
This one really took me round the houses, but the result is a (hopefully) elegant and minimal intervention to make the tooltip much more easily tappable on mobile devices.

It's on `staging` and ready for testing.