### PR TITLE
Footer improvements

### DIFF
--- a/footer.php
+++ b/footer.php
@@ -13,32 +13,12 @@
 
 	<footer id="colophon" class="site-footer">
 
-		<div class="footer-nav">
-			<div class="footer-logos">
-				<a href="https://calls.ars.electronica.art/prix/winners/8535/" target="_blank" rel="noopener noreferrer">
-					<img src="<?php echo get_stylesheet_directory_uri() . '/images/AE_AwardforDigitalHumanity2021.png'; ?>" width="320" height="77" alt="ARS Electronica Award for Digital Humanit 2021 logo">
-				</a>
-			</div>
+		<?php
+		$footer_page = get_page_by_title( 'Footer' );
+		$footer_output = apply_filters( 'the_content', $footer_page->post_content );
 
-			<div class="footer-menu">
-				<a href="/subscribe-to-branch-magazine">
-					<?php echo esc_html__( 'Subscribe to Branch', 'branch' ); ?>
-				</a>
-
-				<a href="<?php echo esc_url( get_permalink( 546 ) ); ?>">
-					<?php echo esc_html__( 'Privacy notice', 'branch' ); ?>
-				</a>
-			</div>
-		</div><!-- .footer-nav -->
-
-		<div class="site-info">
-			<a href="<?php echo esc_url( __( 'https://wordpress.org/', 'branch' ) ); ?>">
-				<?php
-				/* translators: %s: CMS name, i.e. WordPress. */
-				printf( esc_html__( 'Proudly powered by %s', 'branch' ), 'WordPress' );
-				?>
-			</a>
-		</div><!-- .site-info -->
+		echo $footer_output;
+		?>
 		
 	</footer><!-- #colophon -->
 </div><!-- #page -->

--- a/functions.php
+++ b/functions.php
@@ -403,6 +403,7 @@ require get_template_directory() . '/inc/contents-sidebar.php';
  */
 function branch_upload_mimes( $existing_mimes ) {
 	$existing_mimes['webp'] = 'image/webp';
+	$existing_mimes['svg'] = 'image/svg+xml';
 	return $existing_mimes;
 }
 add_filter( 'mime_types', 'branch_upload_mimes' );

--- a/style.css
+++ b/style.css
@@ -1029,7 +1029,7 @@ div.show-image {
 }
 
 .hentry {
-	border-bottom: .1em solid #d8d8d8;
+	border-bottom: 1px solid gray;
 	padding-bottom: 5em;
 }
 
@@ -1126,9 +1126,13 @@ div.show-image {
 	}
 }
 
-.site-footer a {
+.site-footer a, .site-footer a span {
 	color: #212121;
 	text-decoration: none;
+}
+
+.site-footer .wp-block-navigation-item span {
+	font-family: 'Rubik Bold';
 }
 
 .footer-nav {
@@ -1139,6 +1143,11 @@ div.show-image {
 		margin-top: 0;
 		display: flex;
 		align-items: center;
+	}
+}
+@media screen and (max-width: 782px) {
+	.site-footer .wp-block-navigation__container {
+		justify-content: center;
 	}
 }
 


### PR DESCRIPTION
As per our card on Trello, tasks for this PR:

- [x] Right align the privacy and subscribe links to the right hand side of the line
- [x] Maybe make the line dark grey like the header if poss
- [x] Make footer area editable (implement widgets)
- [x] Add new GWF logo
- [x] Credit Jack for supplying the server

This is now all set up on [the staging environment](https://branch-staging.climateaction.tech/) with provisional content.

One note: I remembered in doing this that how I've usually tackled the sitemap/page visibility issue is to publish the 'Footer' page privately. This means the content is still accessible in the code to retrieve it, but isn't included in the sitemap and can't be found here: https://branch-staging.climateaction.tech/footer/ (unless you're logged in, of course)