### PR TITLE
Fix gallery alt tag issues

### DIFF
--- a/style.css
+++ b/style.css
@@ -951,7 +951,7 @@ div.show-image {
 
 /* Hide all images by default. How they appear depends on carbon intensity.
  * (Except for specifically whitelisted images and placeholders.) */
-.entry-content figure:not(.no-carbon) img:not(.branch-placeholder-image) {
+.entry-content figure.wp-block-image:not(.no-carbon) img:not(.branch-placeholder-image) {
 	display: none !important;
 }
 

--- a/style.css
+++ b/style.css
@@ -914,12 +914,13 @@ body {
 }
 
 div.carbon-alt {
+	font-style: italic;
+	line-height: 1.3;
 	position: absolute;
     padding: 5%;
 	top: 40%;
 	transform: translateY(-50%);
-	font-style: italic;
-	line-height: 1.3;
+	width: 100%;
 	z-index: -1;
 }
 @media screen and (min-width: 37.5em) {
@@ -941,6 +942,11 @@ div.show-image {
 	text-decoration: underline;
 	cursor: pointer;
 	z-index: -1;
+}
+@media screen and (max-width: 782px) {
+	div.show-image {
+		font-size: .7rem;
+	}
 }
 
 /* Hide all images by default. How they appear depends on carbon intensity.

--- a/style.css
+++ b/style.css
@@ -927,6 +927,9 @@ div.carbon-alt {
 	body:not(.page-id-675) div.carbon-alt {
 		width: 80%;
 		left: 10%;
+	}
+
+	body:not(.page-id-675) div.carbon-alt:not(figure.wp-block-gallery *) {
 		font-size: 2em;
 	}
 }

--- a/style.css
+++ b/style.css
@@ -951,7 +951,8 @@ div.show-image {
 
 /* Hide all images by default. How they appear depends on carbon intensity.
  * (Except for specifically whitelisted images and placeholders.) */
-.entry-content figure.wp-block-image:not(.no-carbon) img:not(.branch-placeholder-image) {
+.entry-content figure.wp-block-image:not(.no-carbon) img:not(.branch-placeholder-image),
+.entry-content .wp-block-image figure:not(.no-carbon) img:not(.branch-placeholder-image) {
 	display: none !important;
 }
 


### PR DESCRIPTION
This PR fixes an issue outlined in #34.

I've fixed the first issue on `staging` and `production` on the editorial side, which I think is the right place to do it. I may look at making this the default behaviour anyway, but by centering the gallery in the editor, the extra space means the captions fit:

![Screenshot 2023-06-16 at 16-14-31 The Museum of the Fossilized Internet - Branch](https://github.com/climateaction-tech/branch-theme/assets/751476/43869dcb-2698-4679-8449-8125bd45bcbb)

On how things look on small screens, I've tweaked the styles to improve things here. These feel pretty good to me on my mobile device. In the medium-term, I'd like to refactor font sizes so that they're totally responsive using [Andy Bell's technique here](https://set.studio/some-simple-ways-to-make-content-look-good/):

![Screenshot 2023-06-16 at 16-22-45 NORCO](https://github.com/climateaction-tech/branch-theme/assets/751476/d829fce7-66bb-4474-8761-2c844a5f754a)

The fix is deployed on `staging`: https://branch-staging.climateaction.tech/issues/issue-4/norco/

And as a bonus, I've included the fix for `.no-carbon` gallery images in this PR!

Fixes #34