### PR TITLE
Fix bug with "very high" carbon intensity

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -330,6 +330,10 @@ function branch_grid_intensity() {
 				setWithExpiry( 'grid-intensity', index, 3600000 )
 			}
 
+			if ( index === "very high" ) {
+				index = "high";
+			}
+
 			changeGridIntensity( index );
 
 			const sleep = (delay) => new Promise((resolve) => setTimeout(resolve, delay));


### PR DESCRIPTION
Our code and design can't currently handle an additional fourth tier of carbon intensity: "very high", and as such this change is currently breaking the site.

This quick fix tells our carbon intensity checker to treat "very high" simply as "high".

Merged and working on `staging`: https://branch-staging.climateaction.tech/