### PR TITLE
Update content-post.php

### DIFF
--- a/template-parts/content-post.php
+++ b/template-parts/content-post.php
@@ -36,7 +36,7 @@
 		<?php endif; ?>
 	</header><!-- .entry-header -->
 
-	<?php branch_post_thumbnail(); ?>
+	<?php //branch_post_thumbnail(); ?>
 
 	<div class="entry-content">
 		<?php


### PR DESCRIPTION
Prevent output of featured image on posts.

It appears that the carbon aware image treatment does not apply to featured images. However, we still want to be able to use the featured image function as it allows us to set a social media image for the post which is very helpful.