### PR TITLE
Update GitHub action runners

### DIFF
--- a/.github/workflows/deploy-to-production.yml
+++ b/.github/workflows/deploy-to-production.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
       - name: Deploy to server

--- a/.github/workflows/deploy-to-staging.yml
+++ b/.github/workflows/deploy-to-staging.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
       - name: Deploy to server (staging)


### PR DESCRIPTION
Our GitHub runners are pinned to Ubuntu 20.04 which is being deprecated. This PR updates them to use the latest LTS version of Ubuntu, which is now common practice for these sorts of actions.